### PR TITLE
一个群对应多个MC服务器时，只会将群消息转发至其中一个服务器

### DIFF
--- a/nonebot_plugin_mcqq/data_source.py
+++ b/nonebot_plugin_mcqq/data_source.py
@@ -68,26 +68,28 @@ async def send_msg_to_mc(bot: Bot, event: Union[GroupMessageEvent, GuildMessageE
     """发送消息到 MC"""
     # 处理来自QQ的消息
     text_msg, msgJson = await msg_process(bot=bot, event=event)
-    client = await get_client(event=event)
-    if client and client['ws_client']:
-        try:
-            await client['ws_client'].send(msgJson)
-            logger.success(f"[MC_QQ]丨发送至 [server:{client['server_name']}] 的消息 \"{text_msg}\"")
-        except websockets.WebSocketException:
-            logger.error(f"[MC_QQ]丨发送至 [Server:{client['server_name']}] 的过程中出现了错误")
-            CLIENTS.remove(client)
+    clients = await get_clients(event=event)
+    for client in clients:
+        if client and client['ws_client']:
+            try:
+                await client['ws_client'].send(msgJson)
+                logger.success(f"[MC_QQ]丨发送至 [server:{client['server_name']}] 的消息 \"{text_msg}\"")
+            except websockets.WebSocketException:
+                logger.error(f"[MC_QQ]丨发送至 [Server:{client['server_name']}] 的过程中出现了错误")
+                CLIENTS.remove(client)
+    
 
-
-async def get_client(event: Union[GroupMessageEvent, GuildMessageEvent]):
-    """获取 服务器名、ws客户端"""
+async def get_clients(event: Union[GroupMessageEvent, GuildMessageEvent]) -> list:
+    """获取 服务器名、ws客户端, 返回client列表"""
+    res = []
     for per_client in CLIENTS:
         for per_server in get_mc_qq_servers_list():
             # 如果 服务器名 == ws客户端中记录的服务器名，且ws客户端存在
-            if per_server['server_name'] == per_client['server_name'] and per_client['ws_client']:
+            if per_server['server_name'] == per_client['server_name'] and per_client['ws_client'] and (per_client not in res):
                 if isinstance(event, GroupMessageEvent):
                     if event.group_id in per_server['group_list']:
-                        return per_client
+                        res.append(per_client)
                 if isinstance(event, GuildMessageEvent):
                     if {"guild_id": event.guild_id, "channel_id": event.channel_id} in per_server['guild_list']:
-                        return per_client
-    return None
+                        res.append(per_client)
+    return res


### PR DESCRIPTION
一个群对应多个MC服务器时，只会将群消息转发至其中一个服务器
我把`get_client`函数改为了`get_clients`，返回一个clients的列表
发送消息到MC时在clients列表里挨个发送
只改了基础版mcqq，没有改支持mcrcon的插件