### PR TITLE
Dev

### DIFF
--- a/nonebot_plugin_mcqq/on_minecraft_msg.py
+++ b/nonebot_plugin_mcqq/on_minecraft_msg.py
@@ -28,7 +28,7 @@ async def handle_mc_msg(event: PlayerChatEvent):
 async def handle_mc_death(event: PlayerDeathEvent):
     await send_mc_msg_to_qq(
         event.server_name,
-        event.death.text if event.death.text else f"{event.player.nickname} 死亡了",
+        event.death.text or f"{event.player.nickname} 死亡了",
     )
 
 
@@ -47,6 +47,5 @@ async def handle_mc_otherevent(event: PlayerAchievementEvent):
     await send_mc_msg_to_qq(
         event.server_name,
         event.achievement.text
-        if event.achievement.text
-        else f"{event.player.nickname} 获得了成就",
+        or f"{event.player.nickname} 获得了成就({event.achievement.key})",
     )

--- a/nonebot_plugin_mcqq/on_minecraft_msg.py
+++ b/nonebot_plugin_mcqq/on_minecraft_msg.py
@@ -1,9 +1,10 @@
 from nonebot import on_message, on_notice
 from nonebot.adapters.minecraft import (
-    BaseChatEvent,
-    BaseDeathEvent,
-    BaseJoinEvent,
-    BaseQuitEvent,
+    PlayerAchievementEvent,
+    PlayerChatEvent,
+    PlayerDeathEvent,
+    PlayerJoinEvent,
+    PlayerQuitEvent,
 )
 
 from .config import plugin_config
@@ -16,19 +17,36 @@ on_mc_notice = on_notice(priority=4, rule=mc_msg_rule)
 
 
 @on_mc_msg.handle()
-async def handle_mc_msg(event: BaseChatEvent | BaseDeathEvent):
-    msg_text = str(event.message)
+async def handle_mc_msg(event: PlayerChatEvent):
+    msg_text = event.player.nickname + plugin_config.say_way + str(event.message)
     if msg_text.startswith("!!"):
         return
-    msg_result = (
-        msg_text
-        if isinstance(event, BaseDeathEvent)
-        else event.player.nickname + plugin_config.say_way + msg_text
-    )
-    await send_mc_msg_to_qq(event.server_name, msg_result)
+    await send_mc_msg_to_qq(event.server_name, msg_text)
 
 
 @on_mc_notice.handle()
-async def handle_mc_notice(event: BaseJoinEvent | BaseQuitEvent):
-    msg_result = f"{event.player.nickname} {'加入' if isinstance(event, BaseJoinEvent) else '退出'}了游戏"
-    await send_mc_msg_to_qq(event.server_name, msg_result)
+async def handle_mc_death(event: PlayerDeathEvent):
+    await send_mc_msg_to_qq(
+        event.server_name,
+        event.death.text if event.death.text else f"{event.player.nickname} 死亡了",
+    )
+
+
+@on_mc_notice.handle()
+async def handle_mc_notice(event: PlayerJoinEvent):
+    await send_mc_msg_to_qq(event.server_name, f"{event.player.nickname} 加入了游戏")
+
+
+@on_mc_notice.handle()
+async def handle_mc_quit(event: PlayerQuitEvent):
+    await send_mc_msg_to_qq(event.server_name, f"{event.player.nickname} 离开了游戏")
+
+
+@on_mc_notice.handle()
+async def handle_mc_otherevent(event: PlayerAchievementEvent):
+    await send_mc_msg_to_qq(
+        event.server_name,
+        event.achievement.text
+        if event.achievement.text
+        else f"{event.player.nickname} 获得了成就",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<4"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "nonebot-adapter-minecraft>=1.6.0",
+    "nonebot-adapter-minecraft>=1.7.1",
     "nonebot-adapter-onebot>=2.4.6",
     "nonebot-adapter-qq>=1.6.5",
     "nonebot2[fastapi,httpx,websockets]>=2.4.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot-plugin-mcqq"
-version = "2.7.1"
+version = "2.8.0"
 description = "基于NoneBot的QQ群聊与Minecraft Server消息互通插件"
 authors = [{ name = "17TheWord", email = "17theword@gmail.com" }]
 requires-python = ">=3.10,<4"

--- a/tests/test_on_minecraft_msg.py
+++ b/tests/test_on_minecraft_msg.py
@@ -3,13 +3,19 @@ import uuid
 
 import nonebot
 from nonebot.adapters.minecraft import (
-    Adapter as MinecraftAdapter,
+    AchievementModel,
+    DeathModel,
+    DisplayModel,
+    Player,
+    PlayerAchievementEvent,
+    PlayerChatEvent,
+    PlayerCommandEvent,
+    PlayerDeathEvent,
+    PlayerJoinEvent,
+    PlayerQuitEvent,
 )
 from nonebot.adapters.minecraft import (
-    BaseChatEvent,
-    BaseJoinEvent,
-    BasePlayer,
-    BaseQuitEvent,
+    Adapter as MinecraftAdapter,
 )
 from nonebot.adapters.minecraft import (
     Bot as MinecraftBot,
@@ -20,11 +26,10 @@ from nonebot.adapters.minecraft import (
 from nonebug import App
 import pytest
 
-base_player = BasePlayer(uuid=uuid.uuid4(), nickname="test_player")
+base_player = Player(uuid=uuid.uuid4(), nickname="test_player")
 
 base_event = {
     "server_name": "test_server",
-    "event_name": "test_event",
     "server_version": "test_version",
     "server_type": "test_type",
     "timestamp": int(time.time()),
@@ -45,23 +50,35 @@ async def test_handle_mc_msg(app: App):
             base=MinecraftBot, adapter=mc_adapter, self_id="test_server"
         )
 
-        base_chat_event = BaseChatEvent(
+        player_chat_event = PlayerChatEvent(
             **base_event,
+            event_name="PlayerChatEvent",
             post_type="message",
-            sub_type="chat",
+            sub_type="player_chat",
             message=MinecraftMessage("Hello from Minecraft!"),
         )
 
-        ctx.receive_event(mc_bot, base_chat_event)
+        ctx.receive_event(mc_bot, player_chat_event)
 
-        base_chat_event = BaseChatEvent(
+        player_chat_event = PlayerChatEvent(
             **base_event,
+            event_name="PlayerChatEvent",
             post_type="message",
-            sub_type="chat",
+            sub_type="player_chat",
             message=MinecraftMessage("!!This message should be ignored"),
         )
 
-        ctx.receive_event(mc_bot, base_chat_event)
+        ctx.receive_event(mc_bot, player_chat_event)
+
+        player_command_event = PlayerCommandEvent(
+            **base_event,
+            event_name="PlayerCommandEvent",
+            post_type="message",
+            sub_type="player_command",
+            command="/say Hello Command!",
+        )
+
+        ctx.receive_event(mc_bot, player_command_event)
 
 
 @pytest.mark.asyncio
@@ -76,18 +93,57 @@ async def test_handle_mc_notice(app: App):
             base=MinecraftBot, adapter=mc_adapter, self_id="test_server"
         )
 
-        base_join_event = BaseJoinEvent(
+        player_join_event = PlayerJoinEvent(
             **base_event,
+            event_name="PlayerJoinEvent",
             post_type="notice",
-            sub_type="join",
+            sub_type="player_join",
         )
 
-        ctx.receive_event(mc_bot, base_join_event)
+        ctx.receive_event(mc_bot, player_join_event)
 
-        base_quit_event = BaseQuitEvent(
+        player_quit_event = PlayerQuitEvent(
             **base_event,
+            event_name="PlayerQuitEvent",
             post_type="notice",
-            sub_type="quit",
+            sub_type="player_quit",
         )
 
-        ctx.receive_event(mc_bot, base_quit_event)
+        ctx.receive_event(mc_bot, player_quit_event)
+
+        death = DeathModel(
+            key="minecraft:generic",
+            args=["test_player", "Zombie"],
+            text="test_player was slain by Zombie",
+        )
+
+        player_death_event = PlayerDeathEvent(
+            **base_event,
+            event_name="PlayerDeathEvent",
+            post_type="notice",
+            sub_type="player_death",
+            death=death,
+        )
+
+        ctx.receive_event(mc_bot, player_death_event)
+
+        display = DisplayModel(
+            title="minecraft:achievement.get_wood",
+            frame="goal",
+            description="minecraft:achievement.get_wood.desc",
+        )
+
+        achievement = AchievementModel(
+            key="minecraft:achievement.get_wood",
+            display=display,
+            text="Player has earned the achievement [Getting Wood]",
+        )
+
+        player_achievement_event = PlayerAchievementEvent(
+            **base_event,
+            event_name="PlayerAchievementEvent",
+            post_type="notice",
+            sub_type="player_achievement",
+            achievement=achievement,
+        )
+        ctx.receive_event(mc_bot, player_achievement_event)

--- a/uv.lock
+++ b/uv.lock
@@ -1045,7 +1045,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-mcqq"
-version = "2.7.1"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "nonebot-adapter-minecraft" },

--- a/uv.lock
+++ b/uv.lock
@@ -1001,15 +1001,15 @@ wheels = [
 
 [[package]]
 name = "nonebot-adapter-minecraft"
-version = "1.6.0"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nonebot2", extra = ["fastapi", "httpx", "websockets"] },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/55/0d5a2bcbf19d19c6f0954f9000724c00b201635af1ae7980e03315f89c75/nonebot_adapter_minecraft-1.6.0.tar.gz", hash = "sha256:16fe571e3206f5ee885702afd1dcc2dde9d5e72e84d4f0b28e7d1e5e2e9b5ac1", size = 17485, upload-time = "2025-10-20T11:10:26.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/8f/2dcc33a8e6620949a89531c90e45e14389f4d9c73438aabe6661ef23bfac/nonebot_adapter_minecraft-1.7.1.tar.gz", hash = "sha256:9dfc8f2a6138beb499c3b5034d82a7076fa79d9f22e3f07f829156b652498b9e", size = 15812, upload-time = "2025-11-13T15:27:07.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/9b/c6594df2157dbb280a251bb69f16d35e722f6905755af75252d8b67ec425/nonebot_adapter_minecraft-1.6.0-py3-none-any.whl", hash = "sha256:6e7e4557d008a4106dd6af7de24df4ce2318ff2c061209f58260a9f9b24df106", size = 24094, upload-time = "2025-10-20T11:10:25.484Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/6f6e284bc8405d40b86ece413855c5e9820feb3050a652ee42821e852a8f/nonebot_adapter_minecraft-1.7.1-py3-none-any.whl", hash = "sha256:ab896ac61b496a6daebbc48e4e3f7a24ab0532d805c93616d814326d3b97bb14", size = 19164, upload-time = "2025-11-13T15:27:06.734Z" },
 ]
 
 [[package]]
@@ -1075,7 +1075,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "nonebot-adapter-minecraft", specifier = ">=1.6.0" },
+    { name = "nonebot-adapter-minecraft", specifier = ">=1.7.1" },
     { name = "nonebot-adapter-onebot", specifier = ">=2.4.6" },
     { name = "nonebot-adapter-qq", specifier = ">=1.6.5" },
     { name = "nonebot2", extras = ["fastapi", "httpx", "websockets"], specifier = ">=2.4.3" },


### PR DESCRIPTION
## Sourcery 总结

将事件处理迁移到用于聊天、命令和通知（加入、退出、死亡、成就）的新 Player* 事件类，相应地重构处理器，并更新版本和依赖项。

新功能：
- 支持通过 PlayerCommandEvent 转发玩家命令
- 为玩家加入、退出、死亡和成就事件添加独立的处理器

改进：
- 重构聊天处理以使用 PlayerChatEvent，采用标准化的消息格式和忽略规则

构建：
- 将插件版本提升至 2.8.0，并将 nonebot-adapter-minecraft 依赖更新至 >=1.7.1

测试：
- 更新测试套件以使用 Player* 模型，并为命令和成就事件添加测试

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate event handling to new Player* event classes for chat, commands, and notices (join, quit, death, achievement), refactor handlers accordingly, and update version and dependencies.

New Features:
- Support forwarding of player commands via PlayerCommandEvent
- Add separate handlers for player join, quit, death, and achievement events

Enhancements:
- Refactor chat handling to use PlayerChatEvent with standardized message formatting and ignore rules

Build:
- Bump plugin version to 2.8.0 and update nonebot-adapter-minecraft dependency to >=1.7.1

Tests:
- Update test suite to use Player* models and add tests for command and achievement events

</details>